### PR TITLE
Dependencies: `python3 -m pip install --upgrade numpy Pillow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Often in technology, setting up a pre-requisite like PIP (a python asset install
 Even having set up a number of dependencies just a few weeks ago for this project, I don't remember exactly how I worked through the various error messages. When you try to run the script, if it fails there will often be some useful nugget of information buried in the cryptic response blob. As a rule for life - Google is your friend, and others have probably encountered your exact error message. When asking questions on discord, stackoverflow, or wherever, say very specifically (1) what you've tried (2) what you expect as the result and (3) what issue/error you're encountering. That'll get a lot more useful feedback than just shouting HALP.
 
 # Dependencies
+TL;DR: `python3 -m pip install --upgrade numpy Pillow`
+
 The dependenices were all installed with the terminal/command line. There is documentation abound about terminal generally, and these tools specifically, but unfortunately I did not save copies of the web pages I used. From memory the things I needed to setup were:
 
 - Python 3 (default on my mac was python 2.7)


### PR DESCRIPTION
[`random`](https://docs.python.org/3/library/random.html) is part of the Python standard library so it does not need to be installed.